### PR TITLE
Update package.json so docker run works

### DIFF
--- a/bulletin-board-app/package.json
+++ b/bulletin-board-app/package.json
@@ -18,5 +18,8 @@
     "errorhandler": "^1.4.2",
     "method-override": "^2.3.5",
     "morgan": "^1.6.1"
+  },
+  "scripts": {
+    "start": "node server.js"
   }
 }


### PR DESCRIPTION
Dockerfile tries to run 'start' script with npm which is not present in package.json resulting in an error while running container.