### PR TITLE
Fix package.json, currently breaking Docker's Getting Started guide

### DIFF
--- a/bulletin-board-app/package.json
+++ b/bulletin-board-app/package.json
@@ -13,6 +13,9 @@
     "vue": "^1.0.10",
     "vue-resource": "^0.1.17"
   },
+  "scripts": {
+    "start": "node server.js"
+  },
   "devDependencies": {
     "body-parser": "^1.14.1",
     "errorhandler": "^1.4.2",


### PR DESCRIPTION
Package.json is currently missing the start script causing docker run to fail. This PR fixes it and in return restores the Docker Getting Started guide to working order. See: https://github.com/docker/docker.github.io/issues/11628